### PR TITLE
fix: Fix adding unwanted class 'null'

### DIFF
--- a/src/replace.js
+++ b/src/replace.js
@@ -41,7 +41,7 @@ function replaceElement(element, options) {
     return;
   }
 
-  const elementClassAttr = element.getAttribute('class');
+  const elementClassAttr = element.getAttribute('class') || '';
   const classNames = (
     options.class ? `${options.class} ${elementClassAttr}` : elementClassAttr
   );


### PR DESCRIPTION
If you don't add class to the icon element in markup, then `feather.replace` method generates unwanted class `'null'`, because `element.getAttribute('class')` returns `null`.