### PR TITLE
Add jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Include `feather.js` or `feather.min.js` with a `<script>` tag. These files are 
 Or load the script from a CDN provider.
 
 ```html
+<script scr="https://cdn.jsdelivr.net/npm/feather-icons@3.2.2/dist/feather.min.js"></script>
 <script src="https://unpkg.com/feather-icons/dist/feather.min.js"></script>
 ```
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Include `feather.js` or `feather.min.js` with a `<script>` tag. These files are 
 Or load the script from a CDN provider.
 
 ```html
-<script scr="https://cdn.jsdelivr.net/npm/feather-icons@3.2.2/dist/feather.min.js"></script>
+<!-- choose one -->
+<script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js"></script>
 <script src="https://unpkg.com/feather-icons/dist/feather.min.js"></script>
 ```
 


### PR DESCRIPTION
[jsDelivr](https://www.jsdelivr.com/) is the [fastest opensource cdn](https://www.cdnperf.com/) available and built specifically for production usage. It can serve any project from npm with zero config just like unpkg. This PR adds it to the readme as an alternative to unpkg.