### PR TITLE
Updated replace() to pass id from placeholder element

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,13 +228,13 @@ You can pass `feather.replace()` an `options` object:
 </script>
 ```
 
-All classes on a placeholder element (i.e. `<i>`) will be copied to the `<svg>` tag:
+The id and classes on a placeholder element (i.e. `<i>`) will be copied to the `<svg>` tag:
 
 ```html
-<i class="foo bar" data-feather="circle"></i>
+<i id="my-circle-icon" class="foo bar" data-feather="circle"></i>
 <!--
 <i> will be replaced with:
-<svg class="feather feather-circle foo bar" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle></svg>
+<svg id="my-circle-icon" class="feather feather-circle foo bar" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle></svg>
 -->
 
 <script>

--- a/src/replace.js
+++ b/src/replace.js
@@ -42,11 +42,12 @@ function replaceElement(element, options) {
   }
 
   const elementClassAttr = element.getAttribute('class') || '';
+  const elementId = element.getAttribute('id');
   const classNames = (
     options.class ? `${options.class} ${elementClassAttr}` : elementClassAttr
   );
 
-  const svgString = toSvg(key, Object.assign({}, options, { class: classNames }));
+  const svgString = toSvg(key, Object.assign({}, options, { class: classNames, id: elementId }));
   const svgDocument = new DOMParser().parseFromString(svgString, 'image/svg+xml');
   const svgElement = svgDocument.querySelector('svg');
 

--- a/src/replace.js
+++ b/src/replace.js
@@ -42,12 +42,13 @@ function replaceElement(element, options) {
   }
 
   const elementClassAttr = element.getAttribute('class') || '';
-  const elementId = element.getAttribute('id');
+  const elementIdAttr = element.getAttribute('id');
   const classNames = (
     options.class ? `${options.class} ${elementClassAttr}` : elementClassAttr
   );
 
-  const svgString = toSvg(key, Object.assign({}, options, { class: classNames, id: elementId }));
+  const svgOptions = Object.assign({}, options, { class: classNames, id: elementIdAttr });
+  const svgString = toSvg(key, svgOptions);
   const svgDocument = new DOMParser().parseFromString(svgString, 'image/svg+xml');
   const svgElement = svgDocument.querySelector('svg');
 

--- a/src/to-svg.js
+++ b/src/to-svg.js
@@ -68,7 +68,9 @@ function optionsToAtrributes(options) {
   const attributes = [];
 
   Object.keys(options).forEach(key => {
-    attributes.push(`${key}="${options[key]}"`);
+    if (options[key]) {
+      attributes.push(`${key}="${options[key]}"`);
+    }
   });
 
   return attributes.join(' ');

--- a/src/to-svg.js
+++ b/src/to-svg.js
@@ -35,7 +35,7 @@ export default function toSvg(key, options = {}) {
 
   combinedOptions.class = addDefaultClassNames(combinedOptions.class, key);
 
-  const attributes = optionsToAtrributes(combinedOptions);
+  const attributes = optionsToAttributes(combinedOptions);
 
   return `<svg ${attributes}>${icons[key]}</svg>`;
 }
@@ -64,7 +64,7 @@ function addDefaultClassNames(classNames, key) {
  * @param {Object} options
  * @returns {string}
  */
-function optionsToAtrributes(options) {
+function optionsToAttributes(options) {
   const attributes = [];
 
   Object.keys(options).forEach(key => {


### PR DESCRIPTION
Thanks for the awesome icons, I saw a chance to contribute with #186 and figured I would open up a PR. It does the following.

- Grabs the id from the placeholder element and adds it to the `toSvg()` options parameter.
- Makes `optionsToAttributes()` a bit more nullsafe in case `id` is undefined (or any other attributes that may be added), fixed minor typo.
- Updates the readme to reflect the change.

Closes https://github.com/colebemis/feather/issues/186