### PR TITLE
Add search to home page

### DIFF
--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -1,0 +1,3 @@
+bell: notification
+bell-off: notification-off
+check: tick

--- a/_includes/icon.html
+++ b/_includes/icon.html
@@ -6,7 +6,7 @@
     download
     onclick="ga('send', 'event', 'download', 'click', '{{ include.icon.basename }}');">
     <span class="svg flex-none lh-none">{% include_relative {{ include.icon.path }} %}</span>
-    <span class="ml3 lh-copy f6 f5-ns tc black-60 ellipse icon-name">{{ include.icon.basename }}</span>
-    <span class="dn icon-tags">{{tags}}</span>
+    <span class="icon-name ml3 lh-copy f6 f5-ns tc black-60 ellipse">{{ include.icon.basename }}</span>
+    <span class="icon-tags dn">{{tags}}</span>
   </a>
 </li>

--- a/_includes/icon.html
+++ b/_includes/icon.html
@@ -1,3 +1,4 @@
+{% assign tags = site.data.tags[include.icon.basename] | split: ", " | join " " %}
 <li>
   <a
     href="{{ include.icon.path }}"
@@ -5,6 +6,7 @@
     download
     onclick="ga('send', 'event', 'download', 'click', '{{ include.icon.basename }}');">
     <span class="svg flex-none lh-none">{% include_relative {{ include.icon.path }} %}</span>
-    <span class="ml3 lh-copy f6 f5-ns tc black-60 ellipse">{{ include.icon.basename }}</span>
+    <span class="ml3 lh-copy f6 f5-ns tc black-60 ellipse icon-name">{{ include.icon.basename }}</span>
+    <span class="dn icon-tags">{{tags}}</span>
   </a>
 </li>

--- a/_includes/icons.html
+++ b/_includes/icons.html
@@ -1,4 +1,7 @@
-<div class="w-80 mw8 center">
+<div class="w-80 mw8 center" id="js-icons">
+  <div class="w-100 w-50-ns center mb5">
+    <input class="w-100 f4 pv3 br-pill bn bg-near-white bg-animate hover-bg-light-gray tc search" placeholder="Search" />
+  </div>
   <ul class="icon-grid mv0 pl0 list">
       {% for file in site.static_files %}
         {% if file.path contains 'dist/icons/'  %}

--- a/_includes/icons.html
+++ b/_includes/icons.html
@@ -1,7 +1,9 @@
 <div class="w-80 mw8 center" id="js-icons">
-  <div class="w-100 w-50-ns center mb5">
-    <input class="w-100 f4 pv3 br-pill bn bg-near-white bg-animate hover-bg-light-gray tc search" placeholder="Search" />
-  </div>
+  <input
+    type="search"
+    class="search fuzzy-search input-reset w-100 mb3 pv3 ph3 ph4-ns rubik f5 lh-copy bg-white br1 ba b--black-20"
+    placeholder="Search"
+  />
   <ul class="icon-grid mv0 pl0 list">
       {% for file in site.static_files %}
         {% if file.path contains 'dist/icons/'  %}

--- a/index.html
+++ b/index.html
@@ -45,5 +45,12 @@ links:
   {% include icons.html %}
   {% include footer.html links=page.links %}
 
+  <script src="//cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
+  <script type="text/javascript">
+    var list = new List('js-icons', {
+      valueNames: [ 'icon-name', 'icon-tags' ]
+    })
+  </script>
+
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -11,6 +11,10 @@
   background-color: #0055ff;
 }
 
+input.search {
+  outline: none;
+}
+
 .button {
   display: inline-block;
   padding: 1rem 2rem;

--- a/style.css
+++ b/style.css
@@ -11,10 +11,6 @@
   background-color: #0055ff;
 }
 
-input.search {
-  outline: none;
-}
-
 .button {
   display: inline-block;
   padding: 1rem 2rem;
@@ -106,6 +102,7 @@ input.search {
 }
 
 .carbon-img {
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
   margin-right: 1rem;


### PR DESCRIPTION
👋 Love this icon set. Thought I would have a go at adding search with basic tagging system to the home page as I find myself using the bowser page search on the website almost every time I need to use a new icon. 

The search works off of listjs as I have seen suggested a few times in some issues. The tags are defined using a simple tags.yml file which is loaded using the Jekyl _data folder. Multiple tags can be defined for an icon by separating them with commas or spaces. You may want to bundle the tags into the feather library itself, however, I think it is fine to keep it as a feature of the website and keep the icons to their specific names. 

<img width="1265" alt="screen shot 2017-10-10 at 00 11 58" src="https://user-images.githubusercontent.com/1512593/31362598-3e6e7460-ad51-11e7-8625-421fa4c34f3b.png">

<img width="1268" alt="screen shot 2017-10-10 at 00 12 12" src="https://user-images.githubusercontent.com/1512593/31362599-3e739058-ad51-11e7-84a8-d5208223b4f7.png">


https://github.com/colebemis/feather/issues/44
https://github.com/colebemis/feather/issues/45